### PR TITLE
guard against empty polynomials (which represent zero polynomial now)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,14 @@
 name = "RealPolynomialRoots"
 uuid = "87be438c-38ae-47c4-9398-763eabe5c3be"
 authors = ["jverzani <jverzani@gmail.com> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 julia = "1.2"
+LinearAlgebra = "1.6"
 
 [extras]
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"

--- a/src/anewdsc.jl
+++ b/src/anewdsc.jl
@@ -56,8 +56,10 @@ Mlog(x::T) where {T} = log2(max(one(T), abs(x)))
 
 ## Test if the interval 𝑰=[a,b] has a zero in it
 function zerotest(p, I)
+    isempty(p) && return false
     a,b = I
     a >= b && return true
+
     L′ = max(maximum(precision∘float, p), maximum(precision, (a,b)))
 
     ta, tb = tₐ(a,L′), tₐ(b,L′)
@@ -86,6 +88,7 @@ end
 
 ## test if the interval 𝑰 = [a,b] has exactly 1 root in it
 function onetest(p, I)
+    isempty(p) && return false
     a,b = I
     a >= b && return false
 
@@ -627,7 +630,7 @@ function ANewDsc(p::Container{<:Real}; root_bound=root_bound(p), max_depth=32)
     T = BigFloat
 
     n = length(p) - 1
-    iszero(n) && return State(𝐈{T}[],  𝐈{T}[], NTuple{n+1,eltype(p)}(p))
+    n <= 0 && return State{n+1,T,eltype(p)}(𝐈{T}[],  𝐈{T}[], NTuple{n+1,eltype(p)}(p))
 
     max_depth *= ceil(Int, log2(n+2))
 


### PR DESCRIPTION
The 1.2 tests fail. At some point, should bump minimum versino number to 1.6